### PR TITLE
Time series API

### DIFF
--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -13,6 +13,11 @@ Datapackage tools
 
 .. automodule:: sark.dpkg
 
+Time series API
+---------------
+
+.. automodule:: sark.tseries
+
 Validation functions
 --------------------
 

--- a/sark/dpkg.py
+++ b/sark/dpkg.py
@@ -19,9 +19,11 @@ from sark.helpers import consume, import_from
 _source_ts = ["csv", "xls", "xlsx"]  # "sqlite"
 _pd_types = {
     "boolean": "bool",
-    # "date": "datetime64",
-    # "time": "datetime64",
+    "date": "datetime64",
+    "time": "datetime64",
     "datetime": "datetime64",
+    "year": "datetime64",
+    "yearmonth": "datetime64",
     "integer": "Int64",
     "number": "float",
     "string": "string",

--- a/sark/dpkg.py
+++ b/sark/dpkg.py
@@ -186,6 +186,7 @@ def _schema(resource: Resource, type_map: Dict[str, str]) -> Dict[str, str]:
     Returns
     -------
     Dict[str, str]
+        Dictionary with column names as key, and types as values
 
     """
     return dict(
@@ -196,11 +197,8 @@ def _schema(resource: Resource, type_map: Dict[str, str]) -> Dict[str, str]:
                 [  # fields inside a list
                     (
                         "descriptor",  # Field property
-                        lambda t: (  # str -> dtypes understood by pandas
-                            t["name"],
-                            type_map[t["type"]]
-                            # (_type_d[t["type"]], t["format"]),
-                        ),
+                        # string names -> string dtypes understood by pandas
+                        lambda t: (t["name"], type_map[t["type"]]),
                     )
                 ],
             ),

--- a/sark/tseries.py
+++ b/sark/tseries.py
@@ -63,7 +63,8 @@ def read_timeseries(
 
     If `source_t` is not specified (or set to an empty string), options
     specific to this function are ignored, and all other keyword options are
-    passed on to the backend transparently; it's a noop.
+    passed on to the backend transparently; in case of reading a CSV with
+    Pandas, that would include all valid keywords for `pandas.read_csv`.
 
     Parameters
     ----------

--- a/sark/tseries.py
+++ b/sark/tseries.py
@@ -195,7 +195,6 @@ def from_multicol(fpath: _path_t, *, date_cols: List[_col_t], **kwargs):
     read_timeseries : see for full documentation, main entrypoint for users
 
     """
-    df = pd.read_csv(
-        fpath, parse_dates=[date_cols], index_col=date_cols[0], **kwargs
-    )
+    # NOTE: index_col=0 b/c columns parsed as dates always end up in the front
+    df = pd.read_csv(fpath, parse_dates=[date_cols], index_col=0, **kwargs)
     return df

--- a/sark/tseries.py
+++ b/sark/tseries.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+from typing import List, TypeVar, Union
+from warnings import warn
+
+import pandas as pd
+
+_time_units = (
+    "days",
+    "day",
+    "hours",
+    "hour",
+    "minutes",
+    "minute",
+    "seconds",
+    "second",
+)
+
+_path_t = Union[str, Path]
+_col_t = TypeVar("_col_t", int, str)
+
+
+def read_timeseries(
+    fpath: _path_t,
+    *,
+    date_cols: Union[List[_col_t], None] = None,
+    col_units: Union[str, None] = None,
+    zero_idx: bool = False,
+    source_t: str = "",
+    **kwargs,
+):
+    """Read a time series from a file.
+
+    While the natural way to structure a time series dataset is with the index
+    column as datetime values, with subsequent columns holding other values,
+    there are a few other frequently used structures.
+
+    The first is to structure it as a table:
+
+    ===========  ===  ===  ====  ====  ====
+                  1    2    ..    23    24
+    ===========  ===  ===  ====  ====  ====
+     1/1/2016      0   10    ..   2.3   5.1
+     4/1/2016      3   11    ..   4.3   9.1
+    ===========  ===  ===  ====  ====  ====
+
+    When `source_t` is set to "table", this function reads a tabular dataset,
+    like the one above, and flattens it into a series, while setting the
+    appropriate datetime values as their index.
+
+    The other common structure is to split the datetime values into multiple
+    columns in the table:
+
+    ===========  ======  ======  ======
+      date        time    col1    col2
+    ===========  ======  ======  ======
+     1/1/2016     10:00    42.0    foo
+     4/1/2016     11:00    3.14    bar
+    ===========  ======  ======  ======
+
+    When `source_t` is set to "multicol". this function the table, while
+    combining the designated columns to construct the datetime values, which
+    are then set as the index.
+
+    If `source_t` is not specified (or set to an empty string), options
+    specific to this function are ignored, and all other keyword options are
+    passed on to the backend transparently; it's a noop.
+
+    Parameters
+    ----------
+    fpath : Union[str, Path]
+        Path to the dataset file
+
+    date_cols : List[int, str] (for "multicol" mode)
+        List of columns to be combined to construct the datetime values
+
+    col_units : str (for "table" mode)
+        Time units for the columns
+
+    zero_idx : bool (for "table" mode)
+        Whether the columns are zero indexed.  When the columns represent
+        hours, or minutes, it is common to number them as nth hour.  Which
+        means they are counted starting at 1 instead of 0.  Set this to False
+        if that is the case.
+
+    **kwards : Dict
+        Other keyword arguments passed on to the reader backend.  Any options
+        passed here takes precedence, and overwrites other values inferred from
+        the earlier keyword arguments.
+
+    Returns
+    -------
+    ts : Series/DataFrame
+        The time series is returned as a series or a dataframe depending on the
+        number of other columns that are present.
+
+    Examples
+    --------
+
+    To skip specific rows, maybe because they have bad data, or are empty, you
+    may use the `skiprows` option.  It can be set to a list-like where the
+    entries are row indices (numbers).
+
+    >>> read_timeseries("mydata.csv", source_t="table", col_units="hour",
+    ...     skiprows=range(1522, 5480))  # doctest: +SKIP
+
+    The above example skips rows 1522-5480.
+
+    Similarly, data type of the column values can be controlled by using the
+    `dtype` option.  When set to a `numpy.dtype`, all values will be read as
+    that type, which is probably relevant for the "table" mode.  In the
+    "multicol" mode, the types of the values can be controlled at the column
+    level by setting it to a dictionary, where the key matches a column name,
+    and the value is a valid `numpy.dtype`.
+
+    """
+    # FIXME: parse_dates & index_col assumes input is oriented as portrait
+    if source_t == "table":
+        if col_units is None:
+            raise ValueError("col_units: missing time unit for columns")
+        ts = from_table(
+            fpath, col_units=col_units, zero_idx=zero_idx, **kwargs,
+        )
+    elif source_t == "multicol":
+        if date_cols is None:
+            raise ValueError("date_cols: missing list of datetime columns")
+        ts = from_multicol(fpath, date_cols=date_cols, **kwargs,)
+    else:
+        if source_t:
+            warn(f"{source_t}: unsupported source, falling back to default")
+        ts = pd.read_csv(fpath, **kwargs)
+    return ts
+
+
+def from_table(fpath: _path_t, *, col_units: str, zero_idx: bool, **kwargs):
+    """Read a time series from a tabular file.
+
+    See Also
+    --------
+    read_timeseries : see for full documentation, main entrypoint for users
+
+    """
+    assert col_units in _time_units
+
+    # NOTE: assumption: input is oriented as portrait
+    ts = pd.read_csv(
+        fpath, **{"parse_dates": True, "index_col": 0, **kwargs}
+    ).stack()
+    # FIXME: do we also need support for custom stack level?  How common is a
+    # hierarchical index for columns
+
+    # merge indices
+    ts_idx = pd.DataFrame(ts.index.to_list())
+    ts_delta = pd.to_timedelta(
+        ts_idx.iloc[:, 1].astype(int) - int(not zero_idx), unit=col_units
+    )
+    ts.index = ts_idx.iloc[:, 0] + ts_delta
+    return ts
+
+
+def from_multicol(fpath: _path_t, *, date_cols: List[_col_t], **kwargs):
+    """Read a time series where datetime values are in multiple columns.
+
+    See Also
+    --------
+    read_timeseries : see for full documentation, main entrypoint for users
+
+    """
+    df = pd.read_csv(
+        fpath, parse_dates=[date_cols], index_col=date_cols[0], **kwargs
+    )
+    return df

--- a/sark/tseries.py
+++ b/sark/tseries.py
@@ -74,7 +74,8 @@ def read_timeseries(
         List of columns to be combined to construct the datetime values
 
     col_units : str (for "table" mode)
-        Time units for the columns
+        Time units for the columns.  Accepted values are: "days", "day",
+        "hours", "hour", "minutes", "minute", "seconds", "second".
 
     zero_idx : bool (for "table" mode)
         Whether the columns are zero indexed.  When the columns represent

--- a/testing/test_tseries.py
+++ b/testing/test_tseries.py
@@ -31,6 +31,12 @@ def test_from_multicol(tseries_multicol):
     result = from_multicol(CSV, date_cols=[0, 1])
     tm.assert_frame_equal(result, expected)
 
+    # reordered columns
+    df = df[["A", "B", "time", "date", "C", "D"]]
+    CSV = StringIO(df.to_csv(None, index=False))
+    result = from_multicol(CSV, date_cols=[3, 2])
+    tm.assert_frame_equal(result, expected)
+
 
 def test_read_timeseries(tseries_multicol, tseries_table):
     df, expected = tseries_table

--- a/testing/test_tseries.py
+++ b/testing/test_tseries.py
@@ -1,0 +1,55 @@
+from io import StringIO
+
+import pandas._testing as tm
+import pytest  # noqa: F401
+
+from sark.tseries import read_timeseries, from_table, from_multicol
+
+
+def test_from_table(tseries_table):
+    df, expected = tseries_table
+
+    # 0-indexed
+    CSV = StringIO(df.to_csv(None))
+    result = from_table(CSV, col_units="hour", zero_idx=True)
+    tm.assert_series_equal(result, expected)
+
+    # naturally indexed
+    df.columns = range(1, 25)
+    CSV = StringIO(df.to_csv(None))
+    result = from_table(CSV, col_units="hour", zero_idx=False)
+    tm.assert_series_equal(result, expected)
+
+
+def test_from_multicol(tseries_multicol):
+    df, expected = tseries_multicol
+    CSV = StringIO(df.to_csv(None, index=False))
+    result = from_multicol(CSV, date_cols=[0, 1])
+    tm.assert_frame_equal(result, expected)
+
+
+def test_read_timeseries(tseries_multicol, tseries_table):
+    df, expected = tseries_table
+    CSV = StringIO(df.to_csv(None))  # 0-indexed
+
+    result = read_timeseries(
+        CSV, source_t="table", col_units="hour", zero_idx=True
+    )
+    tm.assert_series_equal(result, expected)
+
+    with pytest.raises(ValueError, match="col_units: .+"):
+        read_timeseries(CSV, source_t="table")
+
+    df, expected = tseries_multicol
+    CSV = StringIO(df.to_csv(None, index=False))
+
+    result = read_timeseries(CSV, source_t="multicol", date_cols=[0, 1])
+    tm.assert_frame_equal(result, expected)
+
+    with pytest.raises(ValueError, match="date_cols: .+"):
+        read_timeseries(CSV, source_t="multicol")
+
+    CSV.seek(0)  # reset stream to the beginning
+    with pytest.warns(UserWarning, match="multi: .+"):
+        result = read_timeseries(CSV, source_t="multi", date_cols=[0, 1])
+        tm.assert_frame_equal(result, df.reset_index(drop=True))


### PR DESCRIPTION
Introduce an API to read non-standard time series datasets. The specifics are outlined in the docstring for `sark/tseries.py::read_timeseries`.  The variations that are supported are:
- [x] time index split into multiple columns
- [x] time series structured as a table